### PR TITLE
Solve Package gnutls was not found in the pkg-config search path

### DIFF
--- a/ffmpeg-compat.spec
+++ b/ffmpeg-compat.spec
@@ -10,7 +10,7 @@
 Summary:        Digital VCR and streaming server
 Name:           ffmpeg-compat
 Version:        0.6.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?_with_amr:1}
 License:        GPLv3+
 %else

--- a/ffmpeg-compat.spec
+++ b/ffmpeg-compat.spec
@@ -26,6 +26,10 @@ Patch2:         0002-Add-unconditional-return-statement-to-yuva420_rgb32_.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  bzip2-devel
+BuildRequires:  gnutls-devel
+BuildRequires:  librtmp-devel
+BuildRequires:  rtmpdump
+
 %{?!_without_dirac:BuildRequires: dirac-devel}
 %{?_with_faac:BuildRequires: faac-devel}
 BuildRequires:  gsm-devel


### PR DESCRIPTION
```
Package gnutls was not found in the pkg-config search path. Perhaps you should add the directory containing `gnutls.pc' to the PKG_CONFIG_PATH environment variable
Package 'gnutls', required by 'librtmp', not found ERROR: librtmp not found

If you think configure made a mistake, make sure you are using the latest version from SVN.  If the latest version fails, report the problem to the ffmpeg-user@mplayerhq.hu mailing list or IRC #ffmpeg on irc.freenode.net. Include the log file "config.err" produced by configure as this will help solving the problem.


RPM build errors:
```

full log version file

https://download.copr.fedorainfracloud.org/results/goddabrouquita8280/fusion-remi/epel-6-i386/07489153-ffmpeg-compat/builder-live.log.gz

build not work

https://copr.fedorainfracloud.org/coprs/goddabrouquita8280/fusion-remi/build/7489153/

after patch

https://download.copr.fedorainfracloud.org/results/goddabrouquita8280/fusion-remi/epel-6-x86_64/07490495-ffmpeg-compat/builder-live.log.gz

build work

https://copr.fedorainfracloud.org/coprs/goddabrouquita8280/fusion-remi/build/7490495/

copr custom code used

copr set Build dependencies: @core @buildsys-build wget rpmdevtools

```
#/!/bin/bash
wget https://download1.rpmfusion.org/free/el/updates/6/SRPMS/ffmpeg-compat-0.6.7-1.el6.src.rpm
rpmdev-extract ffmpeg-compat-0.6.7-1.el6.src.rpm
mv ffmpeg-compat*/* ./
sed -i 's|Release:        1|Release:        2|' "ffmpeg-compat.spec"
sed -i 's|BuildRequires:  bzip2-devel|BuildRequires:  bzip2-devel gnutls-devel librtmp-devel rtmpdump|' "ffmpeg-compat.spec"
```
