### PR TITLE
Solve Package gnutls was not found in the pkg-config search path

### DIFF
--- a/ffmpeg-compat.spec
+++ b/ffmpeg-compat.spec
@@ -26,6 +26,9 @@ Patch2:         0002-Add-unconditional-return-statement-to-yuva420_rgb32_.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  bzip2-devel
+BuildRequires:  gnutls-devel
+BuildRequires:  librtmp-devel
+BuildRequires:  rtmpdump
 %{?!_without_dirac:BuildRequires: dirac-devel}
 %{?_with_faac:BuildRequires: faac-devel}
 BuildRequires:  gsm-devel

--- a/ffmpeg-compat.spec
+++ b/ffmpeg-compat.spec
@@ -10,7 +10,7 @@
 Summary:        Digital VCR and streaming server
 Name:           ffmpeg-compat
 Version:        0.6.7
-Release:        4%{?dist}
+Release:        5%{?dist}
 %if 0%{?_with_amr:1}
 License:        GPLv3+
 %else


### PR DESCRIPTION
```
Package gnutls was not found in the pkg-config search path. Perhaps you should add the directory containing `gnutls.pc' to the PKG_CONFIG_PATH environment variable Package 'gnutls', required by 'librtmp', not found ERROR: librtmp not found

If you think configure made a mistake, make sure you are using the latest version from SVN.  If the latest version fails, report the problem to the ffmpeg-user@mplayerhq.hu mailing list or IRC #ffmpeg on irc.freenode.net. Include the log file "config.err" produced by configure as this will help solving the problem.


RPM build errors:
```

https://github.com/rpmfusion/ffmpeg-compat/pull/1